### PR TITLE
Redirect message page should use UTF-8 charset

### DIFF
--- a/src/Omnipay/Common/Message/AbstractResponse.php
+++ b/src/Omnipay/Common/Message/AbstractResponse.php
@@ -142,6 +142,7 @@ abstract class AbstractResponse implements ResponseInterface
             $output = '<!DOCTYPE html>
 <html>
     <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <title>Redirecting...</title>
     </head>
     <body onload="document.forms[0].submit();">


### PR DESCRIPTION
If some form values are UTF-8 encoded (example: greek characters) then the submitted content is garbled.